### PR TITLE
Ensure exported keys end with a new line to match Termius behavior

### DIFF
--- a/termius-exporter.js
+++ b/termius-exporter.js
@@ -182,7 +182,7 @@ function exportSshKeys(keysByLabel) {
     if (!k.private_key) return;
     const safeName = label.replace(/[<>:"/\\|?*]/g, '_');
 
-    if (!k.private_key.endsWith('\n')) k.private_key = k.private_key + '\n';
+    if (!k.private_key.endsWith('\n')) k.private_key += '\n';
 
     const pemPath = path.join(keysDir, `${safeName}.pem`);
     fs.writeFileSync(pemPath, k.private_key, { mode: 0o600 });

--- a/termius-exporter.js
+++ b/termius-exporter.js
@@ -182,6 +182,8 @@ function exportSshKeys(keysByLabel) {
     if (!k.private_key) return;
     const safeName = label.replace(/[<>:"/\\|?*]/g, '_');
 
+    if (!k.private_key.endsWith('\n')) k.private_key = k.private_key + '\n';
+
     const pemPath = path.join(keysDir, `${safeName}.pem`);
     fs.writeFileSync(pemPath, k.private_key, { mode: 0o600 });
 


### PR DESCRIPTION
Ensures exported keys end with a new line to match Termius behavior. This avoids the following error when using exported keys with openssh: `Load key ".\.ssh\key.pem": invalid format`. 